### PR TITLE
caio 0.9.25 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
-    - sysroot_linux-64 2.17  # [linux64]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
-  skip: true  # [py<36]
+  skip: true  # [py<310]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
   skip: true  # [py<36]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,12 @@ test:
 about:
   home: https://github.com/mosquito/caio
   summary: Asynchronous file IO for Linux Posix and Windows.
+  description: Python bindings for Linux AIO API and simple asyncio wrapper.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  dev_url: https://github.com/mosquito/caio
+  doc_url: https://github.com/mosquito/caio
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
     - caio
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/caio-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   host:
     - pip
     - python
+    - setuptools >=77
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - sysroot_linux-64 2.17  # [linux64]
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
   run:
     - python
 
+# missing 'aiomisc' required for project tests
 test:
   imports:
     - caio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "caio" %}
-{% set version = "0.9.11" %}
+{% set version = "0.9.25" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/caio-{{ version }}.tar.gz
-  sha256: 33ca49789bf2d55bc3f5def36784c4624fbf16b78e9c299a2c7f6f22ac084aa6
+  sha256: 16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
   description: Python bindings for Linux AIO API and simple asyncio wrapper.
   license: Apache-2.0
   license_family: Apache
-  license_file: LICENSE
+  license_file: COPYING
   dev_url: https://github.com/mosquito/caio
   doc_url: https://github.com/mosquito/caio
 


### PR DESCRIPTION
caio 0.9.25 

**Destination channel:** Defaults

### Links

- [PKG-14928]
- dev_url:        https://github.com/mosquito/caio/tree/0.9.25
- conda_forge:    https://github.com/conda-forge/caio-feedstock
- pypi:           https://pypi.org/project/caio/0.9.25
- pypi inspector: https://inspector.pypi.io/project/caio/0.9.25

### Explanation of changes:

- new version number


[PKG-14928]: https://anaconda.atlassian.net/browse/PKG-14928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ